### PR TITLE
Only depend on quickcheck* when doing a nightly build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ hyper = "0.6"
 url = "0.2.*"
 
 [dev-dependencies]
-quickcheck = "0.2"
-quickcheck_macros = "0.2"
+quickcheck = { version = "0.2", optional = true }
+quickcheck_macros = { version = "0.2", optional = true }
 
 [features]
-nightly = []
+nightly = ["quickcheck", "quickcheck_macros"]
 
 [profile.dev]
 opt-level = 0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![deny(warnings)]
 #![cfg_attr(all(test, feature = "nightly"), feature(plugin))]
 #![cfg_attr(all(test, feature = "nightly"), plugin(quickcheck_macros))]
+#[cfg(all(test, feature = "nightly"))] extern crate quickcheck;
+
 
 extern crate hyper;
 extern crate url;
@@ -216,8 +218,6 @@ mod tests {
 
 #[cfg(all(test, feature = "nightly"))]
 mod quicktests {
-    extern crate quickcheck;
-
     use super::*;
     extern crate url;
     use url::Url;


### PR DESCRIPTION
If these dependencies aren't optional, they will be compiled for any `cargo test` build, including ones with a stable compiler. This will fail, because the `quickcheck_macros` crate uses unstable code internally, and hence cannot be built with stable.
